### PR TITLE
Enforce tighter bounds on acceptable go versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/overmindtech/source-template
 
-go 1.21
+go 1.21.4
 
 // Direct dependencies
 require (

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,6 @@ github.com/overmindtech/api-client v0.14.0 h1:zXyjJsIeawNqoWv7FqOjwcqgFpLrDYz7l9
 github.com/overmindtech/api-client v0.14.0/go.mod h1:msdkTAQFlvDGOU4tQk2adk2P8j23uaMWkJ9YRX4wGWI=
 github.com/overmindtech/discovery v0.26.0 h1:OzT3HOBX5v2+lqlaq2i1DlIqXoUeyOzbgDivuHn2/KM=
 github.com/overmindtech/discovery v0.26.0/go.mod h1:ED1FAib0tRsM9A0bINm5/Lsxsi0XkDMbpYNjOQ/AVjY=
-github.com/overmindtech/sdp-go v0.57.0 h1:hUqBij/gmc11TaQF4OOKj15kZH6SZJsObQgeCah0vRc=
-github.com/overmindtech/sdp-go v0.57.0/go.mod h1:G01shsRPrtJBMQb2HizIG1BIst7jG8Q6BZ+G8/9YPHM=
 github.com/overmindtech/sdp-go v0.58.0 h1:HtMQ2xxH8bL8YYpuNF/BD0YYVIQfEYzEbFScW9dRJ6s=
 github.com/overmindtech/sdp-go v0.58.0/go.mod h1:G01shsRPrtJBMQb2HizIG1BIst7jG8Q6BZ+G8/9YPHM=
 github.com/overmindtech/sdpcache v1.6.1 h1:laFibDvdUGeLBIclzM0pS3XtFdby2KnfaM3+Nn/2YuA=


### PR DESCRIPTION
This is to keep this aligned without internal projects