### PR TITLE
maint: reduce binary size in docker image

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -20,7 +20,7 @@ COPY sources/ sources/
 
 # Build
 RUN --mount=type=cache,target=/root/.cache/go-build \
-    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o source main.go
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -trimpath -o source main.go
 
 # Use distroless as minimal base image to package the source binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
```
vscode ➜ /workspace/source-template (reduce_binary_size) $ ls -alh big small 
-rwxr-xr-x 1 vscode vscode 21M Jul  1 14:32 big
-rwxr-xr-x 1 vscode vscode 14M Jul  1 14:31 small
```
RE https://github.com/overmindtech/deploy/issues/868